### PR TITLE
Update CI workflows and clean up redundant steps

### DIFF
--- a/.github/workflows/ci-build-deploy.yml
+++ b/.github/workflows/ci-build-deploy.yml
@@ -2,7 +2,7 @@ name: ci/build-deploy
 
 on:
   workflow_run:
-    workflows: [ "ci/unit-tests" ]
+    workflows: [ "ci/test" ]
     types: [ completed ]
     branches: [ main ]
 
@@ -17,8 +17,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    outputs:
-      image-uri: ${{ steps.output.outputs.image-uri }}
 
     steps:
       - name: Checkout repository
@@ -62,7 +60,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Output image URI
-        id: output
-        run: echo "image-uri=${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_USER_REPOSITORY }}:latest" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,4 +1,4 @@
-name: ci/unit-tests
+name: ci/test
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hackathon User Service
 
-[![CI: Unit Tests](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-unit-test.yml/badge.svg)](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-unit-test.yml)
+[![CI: Tests](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-test.yml/badge.svg)](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-test.yml)
 [![CI: Test Coverage](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-go-test-coverage.yaml/badge.svg)](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-go-test-coverage.yaml)
 [![CI: Security Scan](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-govulncheck.yml/badge.svg)](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-govulncheck.yml)
 [![CI: Go Lint](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-golangci-lint.yml/badge.svg)](https://github.com/FIAP-SOAT-G20/hackathon-user-lambda/actions/workflows/ci-golangci-lint.yml)


### PR DESCRIPTION
## Description

This pull request updates CI workflow names for clarity and removes redundant steps. It also updates relevant references in configurations and the README file.

## Changes

- Renamed `ci/unit-tests` workflow to `ci/test`.
- Updated references to the renamed workflow in dependent configurations.
- Removed unused outputs and steps in `ci-build-deploy.yml`.
- Updated README to reflect the new test workflow badge.

## Additional Information

No additional information.

## Checklist

- [ ] Tests passed
- [ ] Changes are covered by tests
- [ ] Documentation updated
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)