### PR TITLE
fix: change user profile retrieval method from GET to POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ features.
 | `POST` | `/prod/users/register` | Register a new user                 | ❌             |
 | `POST` | `/prod/users/login`    | Authenticate user and get JWT token | ❌             |
 | `GET`  | `/prod/users/me`       | Get current user profile            | ✅             |
-| `GET`  | `/prod/users/{id}`     | Get user profile by ID              | ❌             |
+| `POST` | `/prod/users/{id}`     | Get user profile by ID              | ❌             |
 
 ### POST /prod/users/register
 
@@ -106,7 +106,7 @@ Authorization: Bearer <jwt-token>
 - `401 Unauthorized`: Missing or invalid token
 - `404 Not Found`: User not found
 
-### GET /prod/users/{id}
+### POST /prod/users/{id}
 
 Retrieve user profile information by user ID. This is a public endpoint that doesn't require authentication.
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -148,7 +148,7 @@ func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.API
 		_ = json.Unmarshal(b, &out)
 		return respond(200, out)
 
-	case req.HTTPMethod == "GET" && strings.HasPrefix(normalizePath(req.Path), "/users/"):
+	case req.HTTPMethod == "POST" && strings.HasPrefix(normalizePath(req.Path), "/users/"):
 		pathParts := strings.Split(strings.Trim(req.Path, "/"), "/")
 		if len(pathParts) != 2 {
 			return respond(404, map[string]string{"error": "not found"})


### PR DESCRIPTION
This pull request updates the user profile retrieval endpoint to use the `POST` method instead of `GET` for accessing user profiles by ID. The changes ensure consistency between the API documentation and the actual implementation.

**API endpoint update:**

* Changed the HTTP method for retrieving a user profile by ID from `GET` to `POST` in both the API documentation (`README.md`) and the handler logic in `cmd/api/main.go` to match the implementation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R109) [[3]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL151-R151)