### PR TITLE
Feat: Improve error message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,5 @@ mock:
 		go run go.uber.org/mock/mockgen@latest -source=$$file -destination=internal/core/port/mocks/`basename $$file .go`_mock.go; \
 	done
 
-
 clean:
 	rm -rf $(BIN_DIR)


### PR DESCRIPTION
This pull request improves the error response structure for several API endpoints in `cmd/api/main.go`, making error messages more informative and consistent by including additional context such as error details and the request path. There is also a minor cleanup in the `Makefile`.

**API error response enhancements:**

* All API error responses now include the request path and, where applicable, more specific error details (e.g., parsing errors, invalid token format) to help with debugging and client-side handling. (`cmd/api/main.go`) [[1]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL98-R106) [[2]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL115-R123) [[3]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL133-R145) [[4]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL154-R177)

**Build system cleanup:**

* Removed an unnecessary blank line in the `Makefile` for improved readability. (`Makefile`)